### PR TITLE
Watch-only wallet when login passphrase is provided a BURST address

### DIFF
--- a/html/ui/js/nrs.server.js
+++ b/html/ui/js/nrs.server.js
@@ -174,7 +174,7 @@ var NRS = (function(NRS, $, undefined) {
 			currentSubPage = NRS.currentSubPage;
 		}
 
-		var type = ("secretPhrase" in data ? "POST" : "GET");
+		var type = (("secretPhrase" in data) || (data.broadcast == "false") ? "POST" : "GET");
 		var url = NRS.server + "/burst?requestType=" + requestType;
 
 		if (type == "GET") {

--- a/html/ui/js/nrs.server.js
+++ b/html/ui/js/nrs.server.js
@@ -174,7 +174,7 @@ var NRS = (function(NRS, $, undefined) {
 			currentSubPage = NRS.currentSubPage;
 		}
 
-		var type = (("secretPhrase" in data) || (data.broadcast == "false") ? "POST" : "GET");
+		var type = ("secretPhrase" in data ? "POST" : "GET");
 		var url = NRS.server + "/burst?requestType=" + requestType;
 
 		if (type == "GET") {


### PR DESCRIPTION
When the login passphrase box is provided with a BURST- address, login to the wallet as “watch-only”.

Note this is a pretty ham-fisted way to accomplish this function.  LithStud on Discord has some code in his personal repo that is a much more elegant solution.  (It modifies the login UI and allows you to toggle between passphrase and address, with a formatted BURST- entry line for watch-only address).

Nonetheless, I needed something like this for my own development, and I submit this pull request for your consideration.  If a more elegant solution is available, then I say go with that.  But I think a watch-only feature is needed more generally, so this might be "better than nothing".