### PR TITLE
Removed cdn dependency for bootstrap and jquery

### DIFF
--- a/html/ui/index.html
+++ b/html/ui/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <!--atcrowdfund-->
     <!--end-->
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
+    <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" />
     <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css"  />
     <link href="css/ionicons.min.css" rel="stylesheet" type="text/css" />
     <link href="css/app.css" rel="stylesheet" type="text/css" />

--- a/html/ui/index.html
+++ b/html/ui/index.html
@@ -17,7 +17,7 @@
     <style id="user_boxes_style" type="text/css"></style>
     <!-- Reconsider this jquery input as its a multiple of the one in 3rd party folder, one posibility might be to add jquery here but remove from 3rd party
          same with the import i removed for bootstrap.js. Duplicate imports for scripts might cause some spectacular and hard to trace bugs -->
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
+    <script type="text/javascript" src="js/jquery.min.js" type="text/javascript"></script>
     <style>
       .animate-change {
       background-color:green;

--- a/html/ui/js/nrs.js
+++ b/html/ui/js/nrs.js
@@ -71,11 +71,11 @@ var NRS = (function(NRS, $, undefined) {
 	var isScanning = false;
 
 	NRS.init = function() {
-		if (window.location.port && window.location.port != "6876") {
-			$(".testnet_only").hide();
-		} else {
+		if (window.location.port && window.location.port == "6876") {
 			NRS.isTestNet = true;
 			$(".testnet_only, #testnet_login, #testnet_warning").show();
+		} else {
+			$(".testnet_only").hide();
 		}
 
 		if (!NRS.server) {

--- a/html/ui/rewardassignment.html
+++ b/html/ui/rewardassignment.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
+    <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" />
   </head>
   <body class="container">
     <div>


### PR DESCRIPTION
We already have bootstrap.min.css in our css folder. There is no need to use external requests to other sites.
I downloaded the jquery to the js folder, so we can load form the local machine.
Updated nrs.js so it won't show testnet warning if you are using reverse proxy. This closes #41 .