### PR TITLE
Add ‘set reward recipient’ to settings menu

### DIFF
--- a/html/ui/index.html
+++ b/html/ui/index.html
@@ -381,7 +381,8 @@
               <ul class="dropdown-menu dropdown-menu-settings" role="menu">
                 <li><a href="#" class="goto-page" data-page="settings" data-i18n="settings">Settings</a></li>
                 <li><a href="#" data-toggle="modal" data-target="#token_modal" data-i18n="generate_token">Generate Token</a></li>
-                <li><a href="#" data-toggle="modal" data-target="#transaction_operations_modal" data-i18n="transaction_operations">Transaction Operations</a></li>
+                <li><a href="#" data-toggle="modal" data-target="#transaction_operations_modal" data-i18n="transaction_operations">Transaction Operations</a></li>                
+                <li><a href="#" data-toggle="modal" data-target="#reward_assignment_modal" data-i18n="reward_assignment">Reward Assignment</a></li>
               </ul>
             </li>
             <li class="dropdown show-dropdown-website">
@@ -4057,6 +4058,67 @@
       </div>
       <!--end Dividends+ code-->
 
+        <!--set reward recipient Code -->
+            <div class="modal fade" id="reward_assignment_modal" tabindex="-1" role="dialog" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-700">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                            <h4 class="modal-title" data-i18n="reward_assignment">Set Reward Assignment</h4>
+                        </div>
+                        <div class="modal-body">                            
+                            <form role="form" autocomplete="off">
+                                <div class="callout callout-danger set_reward_warning" style="display:none" data-i18n="[html]reward_recipient_warning"><strong>Warning</strong>: Setting a so called "reward recipient" means that you define a beneficiary who will get the BURST reward in case should you (= your miner) find a block. In case you are mining with a pool, you enter the pool's address. In case you are solo mining you enter your own address.</div>
+
+                                <div class="callout callout-danger error_message" style="display:none"></div>
+                                <div class="form-group">
+                                    <label for="reward_assignment_recipient" data-i18n="recipient">RECIPIENT</label>
+                                    <div class="input-group">
+                                        <input type="text" class="form-control" name="recipient" id="reward_recipient" placeholder="Recipient Account" data-i18n="[placeholder]recipient_account" autofocus tabindex="1" />
+                                        <span class="input-group-btn btn-group recipient_selector">
+                                            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"><span class="glyphicon glyphicon-user"></span></button>    
+                                            <ul class="dropdown-menu scrollable-menu" role="menu" style="right:0;left:auto;"></ul>
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-xs-6 col-sm-6 col-md-6 advanced_extend" data-normal="6" data-advanced="3">
+                                        <div class="form-group">
+                                            <label for="reward_assignment_fee" data-i18n="fee">FEE</label>
+                                            <div class="input-group">
+                                                <input type="number" name="feeNXT" id="reward_assignment_fee" class="form-control" step="any" min="1" placeholder="Fee" data-i18n="[placeholder]fee" data-default="1" value="1" tabindex="4">
+                                                <span class="input-group-addon">BURST</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-3 col-sm-3 col-md-3 advanced">
+                                        <div class="form-group">
+                                            <label for="reward_assignment_deadline" data-i18n="deadline_hours">DEADLINE (HOURS)</label>
+                                            <input type="number" name="deadline" id="reward_assignment_deadline" class="form-control" placeholder="Deadline" data-i18n="deadline" min="1" data-default="24" value="24" tabindex="5">
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="form-group secret_phrase">
+                                    <label for="reward_assignment_password" data-i18n="passphrase">PASSPHRASE</label>
+                                    <input type="password" name="secretPhrase" id="reward_assignment_password" class="form-control" placeholder="" tabindex="8">
+                                </div>
+                                <div class="form-group advanced" style="margin-bottom:5px">
+                                    <input type="checkbox" name="doNotBroadcast" id="reward_assignment_do_not_broadcast" value="1" /> <label for="reward_assignment_do_not_broadcast" style="font-weight:normal;" tabindex="10" data-i18n="do_not_broadcast">Do Not Broadcast</label>
+                                </div>
+                                <div class="callout account_info" style="display:none;margin-bottom: 0;"></div>
+                                <input type="hidden" name="request_type" value="setRewardRecipient" data-default="setRewardRecipient" />
+                                <input type="hidden" name="converted_account_id" value="" />                                
+                            </form>
+                        </div>
+                        <div class="modal-footer" style="margin-top:0;">
+                            <div class="advanced_info"><strong data-i18n="fee">Fee</strong>: <span class="advanced_fee">1 BURST</span> - <a href="#" data-i18n="advanced">advanced</a></div>
+                            <button type="button" class="btn btn-default" data-dismiss="modal" data-i18n="cancel">Cancel</button>
+                            <button type="button" class="btn btn-primary" data-loading-text="Submitting..." data-i18n="set_reward_assignment;[data-loading-text]submitting">Set Reward Recipient</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        <!--end Reward Recipient Code -->
       <div class="modal fade" id="send_money_modal" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-dialog-700">
           <div class="modal-content">

--- a/html/ui/js/nrs.server.js
+++ b/html/ui/js/nrs.server.js
@@ -519,6 +519,13 @@ var NRS = (function(NRS, $, undefined) {
 					return false;
 				}
 				break;
+
+			case "setRewardRecipient":
+				if (transaction.type !== 20 || transaction.subtype !== 0) {
+					return false;
+				}
+				break;
+
 			case "createPoll":
 				if (transaction.type !== 1 || transaction.subtype !== 2) {
 					return false;

--- a/html/ui/locales/en.json
+++ b/html/ui/locales/en.json
@@ -82,6 +82,8 @@
     "error_public_key_not_specified": "Public key not specified.",
     "incorrect_purchase": "Incorrect purchase.",
     "error_not_a_number": "__field__ should be numeric.",
+    "success_set_reward_recipient": "Your reward recipient has been set successfully!",
+    "error_set_reward_recipient": "An unknown error occured! Your reward recpieint has not been set.",
     "success_sell_alias": "Your alias sale offer has been created successfully!",
     "error_sell_alias": "An unknown error occured! Alias sale offer may or may not be created.",
     "success_transfer_alias": "Your alias has been transferred successfully!",


### PR DESCRIPTION
The current method of setting reward assignment, "rewardassignment.html" requires that the passphrase be sent to the wallet server.

This pull request modifies the wallet a bit to add a menu option and modal dialog to the settings menu.

It uses the standard form processing logic, so in theory, the passphrase is removed from the request, and only the unsigned transaction is sent to/from the server before applying the signature locally in the user's browser.  (You're mileage may vary, use at your own risk, etc)

Recommend that if this is accepted and passes testing, that the rewardassginment.html be updated to (a) warn the user that passphrase is sent to the server and (b) that they should use the menu option provided by this pull request instead.

At time of writing, you can see the code running on my testnet node at https://www.twodot.org:6876/index.html