### PR TITLE
Peer Pruning

### DIFF
--- a/conf/brs-default.properties
+++ b/conf/brs-default.properties
@@ -64,6 +64,10 @@ brs.usePeersDb = yes
 # when debugging and want to limit the peers to those in peersDb or wellKnownPeers.
 brs.getMorePeers = yes
 
+# If database of peers exceed this value more peers will not be downloaded.
+# This value will never be below MaxConnections. To high value will slowdown connections.
+brs.getMorePeersThreshold = 400
+
 # Peer networking connect timeout for outgoing connections.
 P2P.TimeoutConnect_ms = 4000
 # Peer networking read timeout for outgoing connections.

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -582,7 +582,7 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
 
     private void processFork(Peer peer, final List<BlockImpl> forkBlocks, long forkBlockId) {
 
-      logger.warn("We have got a forked chain. Waiting for cache to be processed.");
+      logger.warn("A fork is detected. Waiting for cache to be processed.");
       while (true) {
         synchronized (DownloadCache) {
           if (DownloadCache.size() == 0) {
@@ -630,7 +630,7 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
          */
         if (pushedForkBlocks > 0 && Burst.getBlockchain().getLastBlock().getCumulativeDifficulty()
             .compareTo(curCumulativeDifficulty) < 0) {
-          logger.debug("Pop off caused by peer " + peer.getPeerAddress() + ", blacklisting");
+          logger.warn("Fork was bad and Pop off was caused by peer " + peer.getPeerAddress() + ", blacklisting");
           peer.blacklist();
           List<BlockImpl> peerPoppedOffBlocks = popOffTo(forkBlock);
           pushedForkBlocks = 0;
@@ -644,16 +644,16 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
             try {
               pushBlock(block);
             } catch (BlockNotAcceptedException e) {
-              logger.error(
-                  "Popped off block no longer acceptable: " + block.getJSONObject().toJSONString(),
-                  e);
+              logger.warn("Popped off block no longer acceptable: " + block.getJSONObject().toJSONString(), e);
               break;
             }
           }
         } else {
           myPoppedOffBlocks.forEach(block -> Burst.getTransactionProcessor().processLater(block.getTransactions()));
+          logger.warn("Successfully switched to better chain.");
         }
       } // synchronized
+      logger.warn("Forkprocessing complete.");
       DownloadCache.ResetCache(); // Reset and set cached vars to chaindata.
     }
   };


### PR DESCRIPTION
New option to set how many peers to save in DB.
BootstrapPeers is no longer saved in database.
Getting connections to peers is more agressive.
Better messages while forks appear.
Prevent peers to become empty if you loose internet connection.