### PR TITLE
Remove need for passphrase when using "do-not-broadcast" feature.

### DIFF
--- a/html/ui/index.html
+++ b/html/ui/index.html
@@ -5594,39 +5594,44 @@
         </div>
       </div>
       <div class="modal fade" id="raw_transaction_modal" tabindex="-1" role="dialog" aria-hidden="true">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-              <h4 class="modal-title" data-i18n="raw_transaction_details">Raw Transaction Details</h4>
-            </div>
-            <div class="modal-body">
-              <label data-i18n="unsigned_transaction_bytes">UNSIGNED TRANSACTION BYTES</label>
-              <div class="form-group">
-                <textarea class="form-control" id="raw_transaction_modal_unsigned_transaction_bytes" rows="4"></textarea>
+        <form role="form" id="raw_transaction_form" autocomplete="off">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" data-i18n="raw_transaction_details">Raw Transaction Details</h4>
               </div>
-              <label data-i18n="signed_transaction_bytes">SIGNED TRANSACTION BYTES</label>
-              <div class="form-group">
-                <textarea class="form-control" id="raw_transaction_modal_transaction_bytes" rows="4"></textarea>
-              </div>
-              <div id="raw_transaction_modal_full_hash_container">
-                <label data-i18n="full_transaction_hash">FULL TRANSACTION HASH</label>
+              <div class="modal-body">
+                <div class="callout callout-danger error_message" style="display:none"></div>
+                <label data-i18n="unsigned_transaction_bytes">UNSIGNED TRANSACTION BYTES</label>
                 <div class="form-group">
-                  <textarea class="form-control" id="raw_transaction_modal_full_hash" rows="1"></textarea>
+                  <textarea class="form-control" id="raw_transaction_modal_unsigned_transaction_bytes" rows="4"></textarea>
+                </div>
+                <label data-i18n="signed_transaction_bytes">SIGNED TRANSACTION BYTES</label>
+                <div class="form-group">
+                  <textarea class="form-control" name="transactionBytes" id="raw_transaction_modal_transaction_bytes" rows="4"></textarea>
+                </div>
+                <div id="raw_transaction_modal_full_hash_container">
+                  <label data-i18n="full_transaction_hash">FULL TRANSACTION HASH</label>
+                  <div class="form-group">
+                    <textarea class="form-control" id="raw_transaction_modal_full_hash" rows="1"></textarea>
+                  </div>
+                </div>
+                <div id="raw_transaction_modal_signature_hash_container">
+                  <label data-i18n="signature_hash">SIGNATURE HASH</label>
+                  <div class="form-group">
+                    <textarea class="form-control" id="raw_transaction_modal_signature_hash" rows="1"></textarea>
+                  </div>
                 </div>
               </div>
-              <div id="raw_transaction_modal_signature_hash_container">
-                <label data-i18n="signature_hash">SIGNATURE HASH</label>
-                <div class="form-group">
-                  <textarea class="form-control" id="raw_transaction_modal_signature_hash" rows="1"></textarea>
-                </div>
+              <div class="modal-footer" style="margin-top:0;">
+                <input type="hidden" name="request_type" value="broadcastTransaction"/>
+                <button type="button" class="btn btn-primary" id="raw_transaction_modal_broadcast_button" data-loading-text="Submitting...">Broadcast Transaction</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal" data-i18n="close">Close</button>
               </div>
-            </div>
-            <div class="modal-footer" style="margin-top:0;">
-              <button type="button" class="btn btn-primary" data-dismiss="modal" data-i18n="close">Close</button>
             </div>
           </div>
-        </div>
+        </form>
       </div>
       <div class="modal fade modal-no-hide" id="transaction_operations_modal" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog">

--- a/html/ui/js/nrs.forms.js
+++ b/html/ui/js/nrs.forms.js
@@ -433,6 +433,14 @@ var NRS = (function(NRS, $, undefined) {
 			data.deadline = String(data.deadline * 60); //hours to minutes
 		}
 
+		if (data.doNotBroadcast) {
+			data.broadcast = "false";
+			delete data.doNotBroadcast;
+			if (data.secretPhrase == "") {
+				delete data.secretPhrase;
+			}
+		}
+
 		if ("secretPhrase" in data && !data.secretPhrase.length && !NRS.rememberPassword) {
 			$form.find(".error_message").html($.t("error_passphrase_required")).show();
 			if (formErrorFunction) {
@@ -470,11 +478,6 @@ var NRS = (function(NRS, $, undefined) {
 					return;
 				}
 			}
-		}
-
-		if (data.doNotBroadcast) {
-			data.broadcast = "false";
-			delete data.doNotBroadcast;
 		}
 
 		NRS.sendRequest(requestType, data, function(response) {

--- a/html/ui/js/nrs.server.js
+++ b/html/ui/js/nrs.server.js
@@ -174,7 +174,7 @@ var NRS = (function(NRS, $, undefined) {
 			currentSubPage = NRS.currentSubPage;
 		}
 
-		var type = ("secretPhrase" in data ? "POST" : "GET");
+		var type = (("secretPhrase" in data) || (data.broadcast == "false") ? "POST" : "GET");
 		var url = NRS.server + "/burst?requestType=" + requestType;
 
 		if (type == "GET") {


### PR DESCRIPTION
_Replaces #51. (Some weird git stuff causes a whole host of changes to be attached to #51 unnecessarily)_

Previously, when using the “do not broadcast” feature on transaction modals, you were still required to provide a passphrase. The “raw transaction” dialog that apperars contains both signed and unsigned versions of the transaction bytes. This commit allows you to use “do not broadcast” without providing the passphrase. In such a case, the “raw transaciton” dialog will only show the unsigned transaction bytes.

It also allows you to broadcast the signed transaction bytes directly from the raw transaction modal dialog, if desired (rather than having to copy/paste into the "transaction tools/broadcast transaction" dialog.

To use, enter the transaction details and in "advanced" click "do not broadcast". Do not provide a passphrase. You will get a raw transaction dialog with unsigned bytes, but not signed bytes.

This is useful when combined with #50 ("watch-only" wallet login) to create an unsigned transaction when using a cold wallet without providing the passphrase to the wallet at all.

Side note, I did my best to rebase my changes against the current development master, but looks like like 239 of index.html (a burst logo) may have crept in, in error. An artifact of my attempt to merge changes in the master branch against my changes from 1.3.6cg, I guess.