### PR TITLE
Fixing thread issue for ocl verification

### DIFF
--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -138,8 +138,10 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
           } catch (OCLPoC.PreValidateFailException e) {
             logger.info(e.toString(), e);
             blacklistClean(e.getBlock(), e);
+          }catch (OCLPoC.OCLCheckerException e) {
+            logger.info("Open CL error. slow verify will occur for the next "+oclUnverifiedQueue+" Blocks", e);
           } finally {
-            gpuUsage.release();
+           
           }
         }else { //verify using java
           try {
@@ -148,6 +150,7 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
             logger.error("Block failed to preverify: ", e);
           }
         }
+        gpuUsage.release();
       }
       try {
         Thread.sleep(10);
@@ -645,6 +648,7 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
     if(oclVerify) {
       Burst.getThreadPool().scheduleThread("VerifyPoc", pocVerificationThread, 9);  
     }else {
+      logger.info("going cpu");
       Burst.getThreadPool().scheduleThreadCores("VerifyPoc", pocVerificationThread, 9);  
     }
     

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -106,7 +106,6 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
   private final Runnable pocVerificationThread = () -> {
     boolean verifyWithOcl;
     int QueueThreashold = oclVerify ? oclUnverifiedQueue : 0;
-    logger.info("Started PreVerifier thread");
     while (true) {
       int unVerified = DownloadCache.getUnverifiedSize();
       if (unVerified > QueueThreashold) { //Is there anything to verify


### PR DESCRIPTION
Disable multithreading for preverification thread when using ocl