### PR TITLE
Minor fix for the watch only message

### DIFF
--- a/html/ui/js/brs.login.js
+++ b/html/ui/js/brs.login.js
@@ -204,7 +204,7 @@ var BRS = (function(BRS, $, undefined) {
 			    // Can't use stadard 'dashboard_status' div because it is cleared by other functions.
 			    // So create a similar div for this purpose
 			    var watch_only_message = "You are logged in as a watch-only address.  You will need the full passphrase for most operations."
-			    $(".content").prepend($('<div class="alert-danger alert alert-no-icon" style="padding: 5px; margin-bottom: 15px;">${watch_only_message}</div>'));
+			    $(".content").prepend($(`<div class="alert-danger alert alert-no-icon" style="padding: 5px; margin-bottom: 15px;">${watch_only_message}</div>`));
 			}						
 		    }
 


### PR DESCRIPTION
Very minor issue.  A template literal was used in a normal string, causing `${watch_only_message}` to be rendered to the user interface.

Quick fix replaces straight quotes with back-ticks.
