### PR TITLE
Use correct block height when verifying transactions

### DIFF
--- a/src/brs/Block.java
+++ b/src/brs/Block.java
@@ -272,7 +272,7 @@ public class Block {
     return json;
   }
 
-  static Block parseBlock(JSONObject blockData) throws BurstException.ValidationException {
+  static Block parseBlock(JSONObject blockData, int height) throws BurstException.ValidationException {
     try {
       int version = ((Long) blockData.get("version")).intValue();
       int timestamp = ((Long) blockData.get("timestamp")).intValue();
@@ -295,7 +295,7 @@ public class Block {
     
       for (Object transactionData : transactionsData) {
         Transaction transaction =
-                    Transaction.parseTransaction((JSONObject) transactionData);
+                    Transaction.parseTransaction((JSONObject) transactionData, height);
           if (transaction.getSignature() != null) {
             if (blockTransactions.put(transaction.getId(), transaction) != null) {
               throw new BurstException.NotValidException(

--- a/src/brs/Transaction.java
+++ b/src/brs/Transaction.java
@@ -575,7 +575,7 @@ public class Transaction implements Comparable<Transaction> {
     return json;
   }
 
-  static Transaction parseTransaction(JSONObject transactionData) throws BurstException.NotValidException {
+  static Transaction parseTransaction(JSONObject transactionData, int height) throws BurstException.NotValidException {
     try {
       byte type = ((Long) transactionData.get("type")).byteValue();
       byte subtype = ((Long) transactionData.get("subtype")).byteValue();
@@ -597,11 +597,12 @@ public class Transaction implements Comparable<Transaction> {
       if (transactionType == null) {
         throw new BurstException.NotValidException("Invalid transaction type: " + type + ", " + subtype);
       }
-      Transaction.Builder builder = new Transaction.Builder(version, senderPublicKey,
+      Transaction.Builder builder = new Builder(version, senderPublicKey,
                                                                             amountNQT, feeNQT, timestamp, deadline,
                                                                             transactionType.parseAttachment(attachmentData))
           .referencedTransactionFullHash(referencedTransactionFullHash)
-          .signature(signature);
+          .signature(signature)
+          .height(height);
       if (transactionType.hasRecipient()) {
         long recipientId = Convert.parseUnsignedLong((String) transactionData.get("recipient"));
         builder.recipientId(recipientId);

--- a/src/brs/TransactionProcessorImpl.java
+++ b/src/brs/TransactionProcessorImpl.java
@@ -273,7 +273,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
 
   @Override
   public Transaction parseTransaction(JSONObject transactionData) throws BurstException.NotValidException {
-    return Transaction.parseTransaction(transactionData);
+    return Transaction.parseTransaction(transactionData, blockchain.getHeight());
   }
     
   @Override

--- a/src/brs/TransactionType.java
+++ b/src/brs/TransactionType.java
@@ -745,7 +745,7 @@ public abstract class TransactionType {
         }
 
         @Override
-        public Fee getBaselineFee() {
+        public Fee getBaselineFee(int height) {
           return BASELINE_ASSET_ISSUANCE_FEE;
         }
 
@@ -2328,12 +2328,12 @@ public abstract class TransactionType {
     if (height < BASELINE_FEE_HEIGHT) {
       return 0; // No need to validate fees before baseline block
     }
-    Fee fee = getBaselineFee();
+    Fee fee = getBaselineFee(height);
     return Convert.safeAdd(fee.getConstantFee(), Convert.safeMultiply(appendagesSize, fee.getAppendagesFee()));
   }
 
-  protected Fee getBaselineFee() {
-    return new Fee((fluxCapacitor.isActive(PRE_DYMAXION) ? FEE_QUANT : ONE_BURST), 0);
+  protected Fee getBaselineFee(int height) {
+    return new Fee((fluxCapacitor.isActive(PRE_DYMAXION, height) ? FEE_QUANT : ONE_BURST), 0);
   }
 
   public static final class Fee {


### PR DESCRIPTION
When parsing blocks the fluxcapacitor assumes the current blockchain height for the blocks. If they are downloaded during resync this assumption is false. This PR includes the blocks actual height in the chain