### PR TITLE
Block heights vs. feature activation

### DIFF
--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -826,7 +826,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
       byte[] byteATs = bf.array();
       Block genesisBlock = new Block(-1, 0, 0, 0, 0, transactions.size() * 128,
           digest.digest(), Genesis.getCreatorPublicKey(), new byte[32],
-          Genesis.getGenesisBlockSignature(), null, transactions, 0, byteATs);
+          Genesis.getGenesisBlockSignature(), null, transactions, 0, byteATs, -1);
       blockService.setPrevious(genesisBlock, null);
       addBlock(genesisBlock);
     } catch (BurstException.ValidationException e) {
@@ -1227,7 +1227,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
       block = new Block(getBlockVersion(), blockTimestamp,
           previousBlock.getId(), totalAmountNQT, totalFeeNQT, Burst.getFluxCapacitor().getInt(FluxInt.MAX_PAYLOAD_LENGTH) - payloadSize, payloadHash, publicKey,
           generationSignature, null, previousBlockHash, new ArrayList<>(orderedBlockTransactions), nonce,
-          byteATs);
+          byteATs, previousBlock.getHeight());
 
     } catch (BurstException.ValidationException e) {
       // shouldn't happen because all transactions are already validated

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -752,7 +752,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
 
   @Override
   public void processPeerBlock(JSONObject request) throws BurstException {
-    Block newBlock = Block.parseBlock(request, blockchain.getHeight() + 1);
+    Block newBlock = Block.parseBlock(request, blockchain.getHeight());
     if (newBlock == null) {
       logger.debug("Peer has announced an unprocessable block.");
       return;

--- a/src/brs/TransactionProcessorImpl.java
+++ b/src/brs/TransactionProcessorImpl.java
@@ -273,7 +273,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
 
   @Override
   public Transaction parseTransaction(JSONObject transactionData) throws BurstException.NotValidException {
-    return Transaction.parseTransaction(transactionData, blockchain.getHeight() + 1);
+    return Transaction.parseTransaction(transactionData, blockchain.getHeight());
   }
     
   @Override

--- a/src/brs/util/DownloadCacheImpl.java
+++ b/src/brs/util/DownloadCacheImpl.java
@@ -408,7 +408,7 @@ public final class DownloadCacheImpl {
 
   public int getPoCVersion(long blockId) {
     Block blockImpl = getBlock(blockId);
-    return (blockImpl == null || ! fluxCapacitor.isActive(POC2) ) ? 1 : 2;
+    return (blockImpl == null || ! fluxCapacitor.isActive(POC2, blockImpl.getHeight()) ) ? 1 : 2;
   }
   
   public long getLastBlockId() {

--- a/src/brs/util/MiningPlot.java
+++ b/src/brs/util/MiningPlot.java
@@ -46,7 +46,7 @@ public class MiningPlot {
       data[i] = (byte) (gendata[i] ^ finalhash[i % HASH_SIZE]);
     }
     //PoC2 Rearrangement
-    if (fluxCapacitor.isActive(POC2)) {
+    if (fluxCapacitor.isActive(POC2, blockHeight)) {
       byte[] hashBuffer = new byte[HASH_SIZE];
       int revPos = PLOT_SIZE - HASH_SIZE; //Start at second hash in last scoop
       for (int pos = 32; pos < (PLOT_SIZE / 2); pos += 64) { //Start at second hash in first scoop


### PR DESCRIPTION
This PR adjusts the incorporation of the block height into the feature activation. For past HF the current blockchain height instead of the current block height was used for new blocks. Thus I reverted my commit from earlier.

I also fixed a bug where the wrong heights for flux int were used while resyncing the chain.

Finally this PR ensures that PoC2 is activated ON the defined block height and not AFTER.

Please check the changes carefully.