### PR TITLE
unconfirmed transactions can be retrieved from cache based on timestamp that they got added to it

### DIFF
--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -19,6 +19,7 @@ import brs.services.TimeService;
 import brs.services.TransactionService;
 import brs.statistics.StatisticsManagerImpl;
 import brs.services.AccountService;
+import brs.unconfirmedtransactions.UnconfirmedTransactionStore;
 import brs.util.ThreadPool;
 
 import java.math.BigInteger;

--- a/src/brs/Burst.java
+++ b/src/brs/Burst.java
@@ -314,7 +314,7 @@ public final class Burst {
     Peers.shutdown(threadPool);
     threadPool.shutdown();
     dbCacheManager.close();
-    stores.getUnconfirmedTransactionStore().close();
+
     if(! ignoreDBShutdown) {
       Db.shutdown();
     }

--- a/src/brs/TransactionProcessorImpl.java
+++ b/src/brs/TransactionProcessorImpl.java
@@ -1,8 +1,6 @@
 package brs;
 
-import brs.BurstException.ValidationException;
 import brs.common.Props;
-import brs.db.BurstKey;
 import brs.db.store.Dbs;
 import brs.db.store.Stores;
 import brs.fluxcapacitor.FeatureToggle;
@@ -12,11 +10,11 @@ import brs.services.AccountService;
 import brs.services.PropertyService;
 import brs.services.TimeService;
 import brs.services.TransactionService;
+import brs.unconfirmedtransactions.UnconfirmedTransactionStore;
 import brs.util.JSON;
 import brs.util.Listener;
 import brs.util.Listeners;
 import brs.util.ThreadPool;
-import org.ehcache.Cache;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONStreamAware;

--- a/src/brs/TransactionType.java
+++ b/src/brs/TransactionType.java
@@ -97,7 +97,7 @@ public abstract class TransactionType {
   private static EscrowService escrowService;
 
   // Temporary...
-  static void init(Blockchain blockchain, FluxCapacitor fluxCapacitor,
+  public static void init(Blockchain blockchain, FluxCapacitor fluxCapacitor,
       AccountService accountService, DGSGoodsStoreService dgsGoodsStoreService,
       AliasService aliasService, AssetExchange assetExchange,
       SubscriptionService subscriptionService, EscrowService escrowService) {

--- a/src/brs/db/store/Stores.java
+++ b/src/brs/db/store/Stores.java
@@ -1,6 +1,6 @@
 package brs.db.store;
 
-import brs.UnconfirmedTransactionStore;
+import brs.unconfirmedtransactions.UnconfirmedTransactionStore;
 import brs.db.cache.DBCacheManagerImpl;
 import brs.db.sql.*;
 import brs.services.PropertyService;

--- a/src/brs/services/TimeService.java
+++ b/src/brs/services/TimeService.java
@@ -6,5 +6,7 @@ public interface TimeService {
 
   int getEpochTime();
 
+  long getEpochTimeMillis();
+
   void setTime(FasterTime fasterTime);
 }

--- a/src/brs/services/impl/TimeServiceImpl.java
+++ b/src/brs/services/impl/TimeServiceImpl.java
@@ -14,6 +14,11 @@ public class TimeServiceImpl implements TimeService {
   }
 
   @Override
+  public long getEpochTimeMillis() {
+    return time.getTimeInMillis();
+  }
+
+  @Override
   public void setTime(FasterTime t) {
     time = t;
   }

--- a/src/brs/unconfirmedtransactions/UnconfirmedTransactionTiming.java
+++ b/src/brs/unconfirmedtransactions/UnconfirmedTransactionTiming.java
@@ -1,0 +1,20 @@
+package brs.unconfirmedtransactions;
+
+class UnconfirmedTransactionTiming {
+
+  private long id;
+  private long timestamp;
+
+  public UnconfirmedTransactionTiming(long id, long timestamp) {
+    this.id = id;
+    this.timestamp = timestamp;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+}

--- a/src/brs/util/Time.java
+++ b/src/brs/util/Time.java
@@ -2,11 +2,11 @@ package brs.util;
 
 import brs.Constants;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 public interface Time {
 
   int getTime();
+
+  long getTimeInMillis();
 
   final class EpochTime implements Time {
 
@@ -14,18 +14,8 @@ public interface Time {
       return (int)((System.currentTimeMillis() - Constants.EPOCH_BEGINNING + 500) / 1000);
     }
 
-  }
-
-  final class ConstantTime implements Time {
-
-    private final int time;
-
-    public ConstantTime(int time) {
-      this.time = time;
-    }
-
-    public int getTime() {
-      return time;
+    public long getTimeInMillis() {
+      return ((System.currentTimeMillis() - Constants.EPOCH_BEGINNING + 500));
     }
 
   }
@@ -49,18 +39,8 @@ public interface Time {
       return time + (int)((System.currentTimeMillis() - systemStartTime) / (1000 / multiplier));
     }
 
-  }
-
-  final class CounterTime implements Time {
-
-    private final AtomicInteger counter;
-
-    public CounterTime(int time) {
-      this.counter = new AtomicInteger(time);
-    }
-
-    public int getTime() {
-      return counter.incrementAndGet();
+    public long getTimeInMillis() {
+      return time + ((System.currentTimeMillis() - systemStartTime) / multiplier);
     }
 
   }


### PR DESCRIPTION
- unconfirmed transactions can be retrieved from cache based on timestamp that they got added to it
- moved unconfirmedtransactions to its own package
- timeservice can offer current time of its perceived reality in ms