### PR TITLE
Fee Suggestion

### DIFF
--- a/src/brs/Constants.java
+++ b/src/brs/Constants.java
@@ -67,6 +67,10 @@ public final class Constants {
   public static final int MAX_AUTOMATED_TRANSACTION_NAME_LENGTH = 30;
   public static final int MAX_AUTOMATED_TRANSACTION_DESCRIPTION_LENGTH = 1000;
 
+  public static final int FEE_SUGGESTION_NUMBER_OF_BLOCKS = 10;
+  public static final double FEE_SUGGESTION_NORMAL_INCLUSION_PROBABILITY = 0.5;
+  public static final double FEE_SUGGESTION_EXPRESS_INCLUSION_PROBABILITY = 0.9;
+
   public static final String MIN_VERSION = "2.0.3";
 
   static final long UNCONFIRMED_POOL_DEPOSIT_NQT = (Burst.getPropertyService().getBoolean(Props.DEV_TESTNET) ? 50 : 100) * ONE_BURST;

--- a/src/brs/http/APIServlet.java
+++ b/src/brs/http/APIServlet.java
@@ -174,6 +174,7 @@ public final class APIServlet extends HttpServlet {
     map.put("getATIds", new GetATIds(atService));
     map.put("getATLong", GetATLong.instance);
     map.put("getAccountATs", new GetAccountATs(parameterService, atService, accountService));
+    map.put("getFeeSuggestion", new GetFeeSuggestion());
 
     if (API.enableDebugAPI) {
       map.put("clearUnconfirmedTransactions", new ClearUnconfirmedTransactions(transactionProcessor));

--- a/src/brs/http/GetFeeSuggestion.java
+++ b/src/brs/http/GetFeeSuggestion.java
@@ -1,0 +1,45 @@
+package brs.http;
+
+import brs.util.Convert;
+import brs.util.FeeSuggestion;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONStreamAware;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static brs.http.JSONResponses.INCORRECT_PRIORITY;
+import static brs.http.JSONResponses.MISSING_PRIORITY;
+import static brs.http.common.Parameters.FEE_SUGGESTION_PRIORITY_PARAMETER;
+
+public final class GetFeeSuggestion extends APIServlet.APIRequestHandler {
+
+  GetFeeSuggestion() {
+    super(new APITag[] {APITag.TRANSACTIONS}, FEE_SUGGESTION_PRIORITY_PARAMETER);
+  }
+
+  @Override
+  JSONStreamAware processRequest(HttpServletRequest req) {
+    String priorityParameter = Convert.emptyToNull(req.getParameter(FEE_SUGGESTION_PRIORITY_PARAMETER));
+
+    if (priorityParameter == null) {
+      return MISSING_PRIORITY;
+    }
+
+    FeeSuggestion.Priority priority;
+
+    if(priorityParameter.equalsIgnoreCase("normal")) {
+      priority = FeeSuggestion.Priority.NORMAL;
+    } else if (priorityParameter.equalsIgnoreCase("express")) {
+      priority = FeeSuggestion.Priority.EXPRESS;
+    } else {
+      return INCORRECT_PRIORITY;
+    }
+
+    JSONObject response = new JSONObject();
+    long fee = FeeSuggestion.suggestFee(priority);
+    response.put("suggestedFee", fee);
+
+    return response;
+  }
+
+}

--- a/src/brs/http/JSONResponses.java
+++ b/src/brs/http/JSONResponses.java
@@ -108,6 +108,9 @@ public final class JSONResponses {
   public static final JSONStreamAware UNKNOWN_AT = unknown(AT_PARAMETER);
   public static final JSONStreamAware INCORRECT_AT = incorrect(AT_PARAMETER);
   public static final JSONStreamAware INCORRECT_CREATION_BYTES = incorrect("incorrect creation bytes");
+
+  public static final JSONStreamAware MISSING_PRIORITY = missing(FEE_SUGGESTION_PRIORITY_PARAMETER);
+  public static final JSONStreamAware INCORRECT_PRIORITY = incorrect(FEE_SUGGESTION_PRIORITY_PARAMETER);
     
     
   public static final JSONStreamAware NOT_ENOUGH_FUNDS;

--- a/src/brs/http/common/Parameters.java
+++ b/src/brs/http/common/Parameters.java
@@ -120,6 +120,7 @@ public class Parameters {
   public static final String ESCROWS_RESPONSE = "escrows";
   public static final String ACCOUNTS_RESPONSE = "accounts";
   public static final String RECIPIENTS_RESPONSE = "recipients";
+  public static final String FEE_SUGGESTION_PRIORITY_PARAMETER = "priority";
 
   public static boolean isFalse(String text) {
     return "false".equalsIgnoreCase(text);

--- a/src/brs/util/FeeSuggestion.java
+++ b/src/brs/util/FeeSuggestion.java
@@ -1,0 +1,85 @@
+package brs.util;
+
+import brs.*;
+import brs.db.BurstIterator;
+import brs.fluxcapacitor.FluxInt;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static brs.Constants.*;
+
+public class FeeSuggestion {
+
+    public enum Priority {
+        NORMAL, EXPRESS
+    }
+
+    public static long suggestFee(Priority priority) {
+        // TODO: throw error if pre-dymxion is not yet enabled?
+        BurstIterator<Block> blocks = Burst.getBlockchain().getBlocks(0, FEE_SUGGESTION_NUMBER_OF_BLOCKS);
+
+        List<List<Long>> fees = extractPaymentFees(blocks);
+
+        int slotCount = Burst.getFluxCapacitor().getInt(FluxInt.MAX_NUMBER_TRANSACTIONS);
+
+        switch (priority) {
+            case EXPRESS:
+                return suggestFee(fees, FEE_SUGGESTION_EXPRESS_INCLUSION_PROBABILITY, slotCount);
+            case NORMAL:
+            default:
+            return suggestFee(fees, FEE_SUGGESTION_NORMAL_INCLUSION_PROBABILITY, slotCount);
+        }
+    }
+
+    private static List<List<Long>> extractPaymentFees(BurstIterator<Block> blocks) {
+        List<List<Long>> fees = new ArrayList<>();
+        for (BurstIterator<Block> it = blocks; it.hasNext(); ) {
+            Block block = it.next();
+            List<Long> fee = block.getTransactions()
+                    .stream()
+                    .filter(t -> t.getType().getType() == 0) // TODO: figure type is payment
+                    .map(Transaction::getFeeNQT)
+                    .collect(Collectors.toList());
+            fees.add(fee);
+        }
+        return fees;
+    }
+
+    static long suggestFee(List<List<Long>> historicFees, double inclusionProbability,
+                           int slotCount) {
+        List<Long> lowestSlotFees = new ArrayList<>(historicFees.size());
+        for (List<Long> fees : historicFees) {
+            fees.sort(Collections.reverseOrder());
+
+            // assign tx to slot
+            boolean[] slots = new boolean[slotCount];
+            for (int slot = slotCount, feeIndex = 0; slot >= 0 && feeIndex < fees.size(); --slot) {
+                Long fee = fees.get(feeIndex);
+                long slotFee = (slot + 1) * FEE_QUANT;
+                if (fee >= slotFee) {
+                    feeIndex += 1;
+                    slots[slot] = true;
+                }
+            }
+
+            // take min cost slot
+            long lowestSlotFee = slotCount * FEE_QUANT;
+            for (int i = 0; i < slots.length; ++i) {
+                if (!slots[i]) {
+                    lowestSlotFee = (i + 1) * FEE_QUANT;
+                    break;
+                }
+            }
+
+            lowestSlotFees.add(lowestSlotFee);
+        }
+
+        Collections.sort(lowestSlotFees);
+
+        int index = Math.min(lowestSlotFees.size() - 1, (int) Math.ceil(inclusionProbability * lowestSlotFees.size()));
+        return lowestSlotFees.get(index);
+    }
+}

--- a/test/java/brs/util/FeeSuggestionTest.java
+++ b/test/java/brs/util/FeeSuggestionTest.java
@@ -1,0 +1,58 @@
+package brs.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static brs.Constants.FEE_QUANT;
+
+public class FeeSuggestionTest {
+
+    @Test
+    public void testSimple() {
+        List<List<Long>> fees = Arrays.asList(Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 4 * FEE_QUANT));
+
+        Assert.assertEquals(3 * FEE_QUANT, FeeSuggestion.suggestFee(fees, 0.5, 1020));
+    }
+
+    @Test
+    public void test() {
+        List<List<Long>> fees = Arrays.asList(
+                Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 3 * FEE_QUANT),
+                Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 3 * FEE_QUANT),
+                Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 3 * FEE_QUANT, 4 * FEE_QUANT),
+                Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 3 * FEE_QUANT, 4 * FEE_QUANT)
+        );
+
+        Assert.assertEquals(4 * FEE_QUANT, FeeSuggestion.suggestFee(fees, 0.5, 1020));
+        Assert.assertEquals(5 * FEE_QUANT, FeeSuggestion.suggestFee(fees, 0.7, 1020));
+    }
+
+    @Test
+    public void testFull() {
+        List<List<Long>> fees = Arrays.asList(
+                Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 3 * FEE_QUANT),
+                Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 3 * FEE_QUANT),
+                Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 3 * FEE_QUANT),
+                Arrays.asList(FEE_QUANT, 2 * FEE_QUANT, 3 * FEE_QUANT)
+        );
+
+        Assert.assertEquals(3 * FEE_QUANT, FeeSuggestion.suggestFee(fees, 0.5, 3));
+        Assert.assertEquals(3 * FEE_QUANT, FeeSuggestion.suggestFee(fees, 0.7, 3));
+    }
+
+    @Test
+    public void testEmpty() {
+        List<List<Long>> fees = Arrays.asList(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList()
+        );
+
+        Assert.assertEquals(FEE_QUANT, FeeSuggestion.suggestFee(fees, 0.5, 3));
+        Assert.assertEquals(FEE_QUANT, FeeSuggestion.suggestFee(fees, 0.7, 3));
+    }
+}


### PR DESCRIPTION
This is a first attempt at suggesting a transaction fee based on the current transaction load on the blockchain. It looks at the last couple of blocks to find out what min fee would have been needed to include a transaction into the block. It then calculates, depending on the priority, how much fee would have been necessary to be included in a given percentage of blocks.

A GUI integration is still missing.

Feedback is greatly appreciated.