### PR TITLE
add null test for peer version comparison

### DIFF
--- a/html/ui/js/brs.update.js
+++ b/html/ui/js/brs.update.js
@@ -123,10 +123,10 @@ var BRS = (function(BRS, $, undefined) {
     };
 
     BRS.versionCompare = function(v1, v2) {
-        if (v2 === undefined) {
+        if (v2 === undefined || v2 === null) {
             return -1;
         }
-        else if (v1 === undefined) {
+        else if (v1 === undefined || v1 === null) {
             return -1;
         }
 


### PR DESCRIPTION
The peer bwallet.burstmining.club:8125 is currently not announcing its version. If you are connected to this peer, the Peers page in the UI will fail to load:

jQuery.Deferred exception: Cannot read property 'slice' of null TypeError: Cannot read property 'slice' of null

This PR adds an additional null check to BRS.versionCompare to fix this error.