### PR TITLE
Fix BRS.convertToNQT bug

### DIFF
--- a/html/ui/js/brs.util.js
+++ b/html/ui/js/brs.util.js
@@ -371,7 +371,11 @@ var BRS = (function(BRS, $, undefined) {
         }
     };
     BRS.convertToNQT = function(currency) {
+
+        if(!isNaN(currency))
         currency = currency.toFixed(8);  ///  this fixes rounding issues (for the Total field on modals)
+        else
+        currency = String(currency);
         var parts = currency.split(".");
 
         var amount = parts[0];


### PR DESCRIPTION
The previous fix to the rounding issue of BRS.convertToNQT didnt take into account that  BRS.convertToNQT could have string as an argument (assumption was it is number only). Brabatian found a bug trying to register an Alias. 