### PR TITLE
Peer GetBlocksFromHeight

### DIFF
--- a/src/brs/peer/GetBlocksFromHeight.java
+++ b/src/brs/peer/GetBlocksFromHeight.java
@@ -1,0 +1,53 @@
+package brs.peer;
+
+import brs.Block;
+import brs.Blockchain;
+import brs.util.Convert;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONStreamAware;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class GetBlocksFromHeight extends PeerServlet.PeerRequestHandler {
+
+  private final Blockchain blockchain;
+
+  GetBlocksFromHeight(Blockchain blockchain) {
+    this.blockchain = blockchain;
+  }
+
+
+  @Override
+  JSONStreamAware processRequest(JSONObject request, Peer peer) {
+    JSONObject response = new JSONObject();
+    List<Block> nextBlocks = new ArrayList<>();
+    int blockHeight = Convert.parseInteger(request.get("height").toString());
+    int numBlocks = 100;
+    try {
+      numBlocks = Convert.parseInteger(request.get("numBlocks").toString());
+    }catch (Exception e) {}
+    //small failsafe
+    if(numBlocks <1 || numBlocks >1400) {
+    	numBlocks = 100;
+    }
+    if(blockHeight <0) {
+    	blockHeight = 0;
+    }
+    	    
+    long blockId =  blockchain.getBlockIdAtHeight(blockHeight);
+    List<? extends Block> blocks = blockchain.getBlocksAfter(blockId, numBlocks);
+    for (Block block : blocks) {
+      nextBlocks.add(block);
+    }
+
+    JSONArray nextBlocksArray = new JSONArray();
+    for (Block nextBlock : nextBlocks) {
+      nextBlocksArray.add(nextBlock.getJSONObject());
+    }
+    response.put("nextBlocks", nextBlocksArray);
+    return response;
+  }
+
+}

--- a/src/brs/peer/PeerServlet.java
+++ b/src/brs/peer/PeerServlet.java
@@ -47,6 +47,7 @@ public final class PeerServlet extends HttpServlet {
     map.put("getInfo", new GetInfo(timeService));
     map.put("getMilestoneBlockIds", new GetMilestoneBlockIds(blockchain));
     map.put("getNextBlockIds", new GetNextBlockIds(blockchain));
+    map.put("getBlocksFromHeight", new GetBlocksFromHeight(blockchain));
     map.put("getNextBlocks", new GetNextBlocks(blockchain));
     map.put("getPeers", GetPeers.instance);
     map.put("getUnconfirmedTransactions", new GetUnconfirmedTransactions(transactionProcessor));


### PR DESCRIPTION
Return from this function is same as GetNextBlocks

**Usage:**
{"protocol":"B1","requestType":"GetBlocksFromHeight","height":"100","numBlocks":"100"}

**height** 
specifies the height of the starting block. Returns blocks after this height.

**numBlocks** 
How many blocks to return in the request as max. Default is 100. this param can be omitted. min value is 1 and max value is 1400. 