### PR TITLE
Add Dockerfiles for automated builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ burst.jar
 brs.log
 brs.log.*
 /conf/logging.properties
-/conf/brs.properties*
+/conf/brs.properties
 _config.yml
 /html/ui/doc/*
 target

--- a/Dockerfile.h2
+++ b/Dockerfile.h2
@@ -13,4 +13,4 @@ COPY conf/brs.properties.h2 /conf/brs.properties
 COPY conf/brs-default.properties /conf/brs-default.properties
 COPY conf/logging-default.properties /conf/logging-default.properties
 EXPOSE 8125 8123
-ENTRYPOINT ["java", "-classpath", "/app/burst.jar:/conf", "-Ddev=1", "brs.Burst"]
+ENTRYPOINT ["java", "-classpath", "/app/burst.jar:/conf", "brs.Burst"]

--- a/Dockerfile.h2
+++ b/Dockerfile.h2
@@ -1,0 +1,16 @@
+FROM maven:3-jdk-8-alpine as builder
+WORKDIR /app
+COPY . .
+RUN ./burst.sh compile
+
+FROM openjdk:8-jdk-alpine
+RUN apk update && apk upgrade && apk add --no-cache bash
+WORKDIR /app
+COPY --from=builder /app/burst.jar .
+COPY html html
+VOLUME ["/conf", "/db"]
+COPY conf/brs.properties.h2 /conf/brs.properties
+COPY conf/brs-default.properties /conf/brs-default.properties
+COPY conf/logging-default.properties /conf/logging-default.properties
+EXPOSE 8125 8123
+ENTRYPOINT ["java", "-classpath", "/app/burst.jar:/conf", "-Ddev=1", "brs.Burst"]

--- a/Dockerfile.mariadb
+++ b/Dockerfile.mariadb
@@ -1,0 +1,16 @@
+FROM maven:3-jdk-8-alpine as builder
+WORKDIR /app
+COPY . .
+RUN ./burst.sh compile
+
+FROM openjdk:8-jdk-alpine
+RUN apk update && apk upgrade && apk add --no-cache bash
+WORKDIR /app
+COPY --from=builder /app/burst.jar .
+COPY html html
+VOLUME ["/conf"]
+COPY conf/brs.properties.mariadb /conf/brs.properties
+COPY conf/brs-default.properties /conf/brs-default.properties
+COPY conf/logging-default.properties /conf/logging-default.properties
+EXPOSE 8125 8123
+ENTRYPOINT ["java", "-classpath", "/app/burst.jar:/conf", "-Ddev=1", "brs.Burst"]

--- a/Dockerfile.mariadb
+++ b/Dockerfile.mariadb
@@ -13,4 +13,4 @@ COPY conf/brs.properties.mariadb /conf/brs.properties
 COPY conf/brs-default.properties /conf/brs-default.properties
 COPY conf/logging-default.properties /conf/logging-default.properties
 EXPOSE 8125 8123
-ENTRYPOINT ["java", "-classpath", "/app/burst.jar:/conf", "-Ddev=1", "brs.Burst"]
+ENTRYPOINT ["java", "-classpath", "/app/burst.jar:/conf", "brs.Burst"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,56 @@ DB.Username=brs_user
 DB.Password=yourpassword
 ```
 
+### Docker
+
+`latest` : Latest master of the BRS with H2 database  
+`mariadb` : Latest master of the BRS with MariaDB database  
+`2.3.0-h2`, `2.3-h2` : Version 2.3.0 of the BRS with H2 database  
+`2.3.0-mariadb`, `2.3-mariadb` : Version 2.3.0 of the BRS with MariaDB database  
+
+
+**Note (H2 only):**  
+H2 dump username and password has been changed through updates. The current dump has the user 'sa' and password 'sa' which is used in the BRS 2.2.1 image. If you get username errors, please mount your custom config for your H2 file.
+
+Old username and passwords:
+
+- both empty  
+  or
+- burst - burst
+
+---
+##### MariaDB
+
+```
+version: '3'
+
+services:
+  burstcoin:
+    image: burstcoin/core:2.3-mariadb
+    restart: always
+    depends_on:
+     - mariadb
+    ports:
+     - 8123:8123
+     - 8125:8125
+  mariadb:
+    image: mariadb:10
+    environment:
+     - MYSQL_ROOT_PASSWORD=burst
+     - MYSQL_DATABASE=burst
+    command: mysqld --character_set_server=utf8mb4
+    volumes:
+     - ./burst_db:/var/lib/mysql
+```
+
+---
+##### H2
+
+```
+docker run -p 8123:8123 -p 8125:8125 -v "$(pwd)"/burst_db:/db -d burstcoin/core:2.3-h2
+```
+
+
 ## Upgrading
 
 Ensure the PoC-Consortium github is in your list of remotes: 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ DB.Password=yourpassword
 
 ### Docker
 
-`latest` : Latest master of the BRS with H2 database  
-`mariadb` : Latest master of the BRS with MariaDB database  
-`2.3.0-h2`, `2.3-h2` : Version 2.3.0 of the BRS with H2 database  
-`2.3.0-mariadb`, `2.3-mariadb` : Version 2.3.0 of the BRS with MariaDB database  
+`latest` : Latest tag of the BRS with H2 database  
+`mariadb` : Latest tag of the BRS with MariaDB database  
+`2.2.3-h2`, `2.2-h2` : Version 2.2.3 of the BRS with H2 database  
+`2.2.3-mariadb`, `2.2-mariadb` : Version 2.2.3 of the BRS with MariaDB database  
 
 
 **Note (H2 only):**  
@@ -126,7 +126,7 @@ version: '3'
 
 services:
   burstcoin:
-    image: burstcoin/core:2.3-mariadb
+    image: burstcoin/core:2.2-mariadb
     restart: always
     depends_on:
      - mariadb
@@ -147,7 +147,7 @@ services:
 ##### H2
 
 ```
-docker run -p 8123:8123 -p 8125:8125 -v "$(pwd)"/burst_db:/db -d burstcoin/core:2.3-h2
+docker run -p 8123:8123 -p 8125:8125 -v "$(pwd)"/burst_db:/db -d burstcoin/core:2.2-h2
 ```
 
 

--- a/conf/brs.properties.h2
+++ b/conf/brs.properties.h2
@@ -1,0 +1,310 @@
+############################################################
+# Do not modify this file.  Instead, create a file named   #
+# 'brs.properties' in the conf directory and make your     #
+# changes there.                                           #
+# These will overwrite the values defined here!            #
+############################################################
+#
+# Integer parameters can be
+# decimal     123
+# binary      0b100101
+# hexadecimal 0xAF1D
+#
+# Boolean parameters can be
+# 1, true, yes, on
+# 0, false, no, off
+# (case insensitive)
+#
+
+#### PEER 2 PEER NETWORKING ####
+
+# Announce my IP address/hostname to peers and allow them to share it with other peers.
+# If disabled, peer networking servlet will not be started at all.
+P2P.shareMyAddress = yes
+
+# My externally visible IP address or host name, to be announced to peers.
+# It can optionally include a port number, which will also be announced to peers,
+# and may be different from P2P.Port (useful if you do port forwarding behind a router).
+P2P.myAddress =
+
+# Host interface on which to listen for peer networking requests, default all.
+# Use 0.0.0.0 to listen on all IPv4 interfaces or :: to listen on all IPv4 and IPv6 interfaces
+P2P.Listen = 0.0.0.0
+
+# Port for incoming peer to peer networking requests, if enabled.
+P2P.Port = 8123
+
+# Use UPnP-Portforwarding
+P2P.UPnP = yes
+
+# My platform, to be announced to peers.
+P2P.myPlatform = PC
+
+# A list of peer addresses / host names, separated by '; ' used for faster P2P networking bootstrap.
+# TODO: document what is taken if not set
+
+P2P.BootstrapPeers = 163.172.162.223; node.burst.gittam.de; 80.122.157.25; 138.201.247.112; 35.194.43.230; 24.179.36.64; 136.243.54.19; 160.16.52.180; [2a02:c207:2016:1984:0:0:0:1]; wallet.smit.pro; wallet.logg.coffee; 37.205.11.73; 47.95.232.75; 75.100.126.230; 93.73.103.148; wallet.burst.cryptoguru.org; 51.15.95.163; antigo.hopto.org; 61.171.0.50; burst.megash.it; wi3jodsj.dynu.net; 176.31.105.109; 24.51.189.190; burstwallet2.ddns.net; burstsecurity.com; 81.83.5.50; bloodreaver.no-ip.biz; burstnode.devtrue.net; 185.203.117.157; 138.201.159.96; 52.65.42.199; 138.201.159.82; 159.69.21.174; home.schmiemann.online; 221.241.92.2; peer.wallet.burstcoin.ml; [2a03:3b40:100:0:0:0:1:52]; tompkins.ddns.net; 188.68.41.245; wallet.creepminer.net; burstpool.cloud; 173.249.1.215; 91.143.92.133:18123; 80.71.133.195; redfox.org; 146.247.237.139; 77.70.109.7; 117.48.195.3; 144.76.92.28; bangalore.burstsecurity.com; wallet.burstcoin.asia; 78.130.235.166; aa.storj.eu; 195.201.124.43; wallet.daggeringcats.com; 84.113.147.25; 81.169.131.111; 5.39.93.90; 198.100.149.133; 148.251.78.147; 212.32.255.2; 195.201.116.237; 95.216.142.146; 84.72.183.85; 75.100.126.227; 35.207.44.92; 75.100.126.226; 107.150.6.121; burst.sagichdir.net; [2a07:5741:0:b12:0:0:0:1]; 108.238.244.144; 51.15.219.28; 81.217.76.37; bibenwei.com; 82.192.26.82; logg.coffee; burst-fi.megash.it; 87.227.172.104; 45.76.6.179; chorca.com; 87.98.244.116; 5.189.177.212; 207.38.188.197; 83.87.55.43; 151.248.189.93; 45.32.114.77; 95.165.132.145; 91.143.92.133; 85.217.171.59; 78.46.245.194; 47.33.52.184; www.ollb.de; [2001:19f0:4400:6c35:5400:1ff:fe54:840]; 83.170.94.221; kartoffel.space:8000; 185.203.116.80; 39.106.178.146; 62.210.254.125; 80.65.49.246; 88.198.32.19; carless.ddns.net; 89.166.9.172; 94.130.190.156; 45.77.250.34; 144.76.45.125; 95.216.0.50; 185.185.27.163; 75.100.126.22875.100.126.229; [2a07:5741:0:f8c:0:0:0:1]; 5.103.129.103; 213.32.102.141; 63.251.20.214
+
+# These peers will always be sent rebroadcast transactions. They are also automatically added to P2P.BootstrapPeers, so no need for duplicates.
+P2P.rebroadcastTo = 78.46.245.194; 94.130.190.156; 78.130.235.166; 75.100.126.230; 195.201.116.237; 75.100.126.226; 138.201.159.82
+
+# Connect to this many bootstrap connection peers before using the peer database to get connected faster. Please be aware, that higher != better (3-5 are usually good values) Set to 0 or comment out to disable.
+P2P.NumBootstrapConnections = 4
+
+# Known bad peers to be blacklisted
+P2P.BlacklistedPeers =
+
+# Maintain active connections with at least that many peers. Also more != better (you want good peers, not just many)
+P2P.MaxConnections = 20
+
+# Use Peers Database? (Only if not in Offline mode)
+P2P.usePeersDb = yes
+# Save known peers in the PeersDB? (only if P2P.usePeersDB is true)
+P2P.savePeers = yes
+
+# Set to false to disable getting more peers from the currently connected peers. Only useful
+# when debugging and want to limit the peers to those in peersDb or P2P.BootstrapPeers.
+P2P.getMorePeers = yes
+
+# If database of peers exceed this value more peers will not be downloaded.
+# This value will never be below MaxConnections. To high value will slowdown connections.
+P2P.getMorePeersThreshold = 400
+
+# Peer networking connect timeout for outgoing connections.
+P2P.TimeoutConnect_ms = 4000
+# Peer networking read timeout for outgoing connections.
+P2P.TimeoutRead_ms = 8000
+# Peer networking server idle timeout, milliseconds.
+P2P.TimeoutIdle_ms = 30000
+# Blacklist peers for 600000 milliseconds (i.e. 10 minutes by default).
+P2P.BlacklistingTime_ms = 600000
+
+# Enable re-broadcasting of new transactions until they are received back from at least one
+# peer, or found in the blockchain. This feature can optionally be disabled, to avoid the
+# risk of revealing that this node is the submitter of such re-broadcasted new transactions.
+P2P.enableTxRebroadcast = yes
+
+# Transactions that aren't confirmed for this many blocks start getting rebroadcast.
+P2P.rebroadcastTxAfter = 5
+
+# Transactions being rebroadcast get rebroadcast every this many blocks until they are confirmed.
+P2P.rebroadcastTxEvery = 2
+
+# Consider a new transaction or block sent after 10 peers have received it.
+P2P.sendToLimit=10
+
+# Max number of unconfirmed transactions that will be kept in cache.
+P2P.maxUnconfirmedTransactions = 8192
+
+# Max percentage of unconfirmed transactions that have a full hash reference to another transaction kept in cache
+P2P.maxUnconfirmedTransactionsFullHashReferencePercentage = 5
+
+# Max amount of unconfirmed transactions that will be asked to a peer at the same time
+P2P.limitUnconfirmedTransactionsToRetrieve = 1000
+
+# JETTY pass-through options. See documentation at
+# https://www.eclipse.org/jetty/documentation/9.2.22.v20170531/dos-filter.html
+# P2P section:
+JETTY.P2P.DoSFilter                   = on
+JETTY.P2P.DoSFilter.maxRequestsPerSec = 30
+JETTY.P2P.DoSFilter.delayMs           = 500
+JETTY.P2P.DoSFilter.maxRequestMs      = 300000
+JETTY.P2P.DoSFilter.throttleMs        = 30000
+JETTY.P2P.DoSFilter.maxIdleTrackerMs  = 30000
+JETTY.P2P.DoSFilter.maxWaitMs         = 50
+JETTY.P2P.DoSFilter.throttledRequests = 5
+JETTY.P2P.DoSFilter.insertHeaders     = true
+JETTY.P2P.DoSFilter.trackSessions     = false
+JETTY.P2P.DoSFilter.remotePort        = false
+JETTY.P2P.DoSFilter.ipWhitelist       = ""
+JETTY.P2P.DoSFilter.managedAttr       = true
+
+# see https://www.eclipse.org/jetty/documentation/9.2.22.v20170531/gzip-filter.html
+# deflate compression and others ommitted on purpose (pending update to GzipHandler anyway)
+JETTY.P2P.GZIPFilter             = on
+JETTY.P2P.GZIPFilter.methods     = "GET, POST"
+JETTY.P2P.GZIPFilter.bufferSize  = 8192
+JETTY.P2P.GZIPFilter.minGzipSize = 0
+
+# Size of the download cache for blocks
+brs.blockCacheMB = 40
+
+#### API SERVER ####
+
+# Accept http/json API requests.
+API.Server = on
+
+# JETTY pass-through options. See documentation at
+# https://www.eclipse.org/jetty/documentation/9.2.22.v20170531/dos-filter.html
+# API section:
+JETTY.API.DoSFilter                   = off
+JETTY.API.DoSFilter.maxRequestsPerSec = 30
+JETTY.API.DoSFilter.delayMs           = 500
+JETTY.API.DoSFilter.maxRequestMs      = 30000
+JETTY.API.DoSFilter.throttleMs        = 30000
+JETTY.API.DoSFilter.maxIdleTrackerMs  = 30000
+JETTY.API.DoSFilter.maxWaitMs         = 50
+JETTY.API.DoSFilter.throttledRequests = 5
+JETTY.API.DoSFilter.insertHeaders     = true
+JETTY.API.DoSFilter.trackSessions     = false
+JETTY.API.DoSFilter.remotePort        = false
+JETTY.API.DoSFilter.ipWhitelist       = ""
+JETTY.API.DoSFilter.managedAttr       = true
+
+# Jetty-passthrough parameters for API responses GZIP compression. See JETTY.P2P.GZIPFilter
+JETTY.API.GZIPFilter             = off
+JETTY.API.GZIPFilter.methods     = "GET, POST"
+JETTY.API.GZIPFilter.bufferSize  = 8192
+JETTY.API.GZIPFilter.minGzipSize = 0
+
+# Developers or maintenance only! Enable API requests used for
+# blockchain and database manipulation. If this is enabled and your
+# wallet is public, you are very vulnerable.
+API.Debug = off
+
+# Hosts or subnets from which to allow http/json API requests, if enabled.
+# List delimited by ';', IPv4/IPv6 possible, default: localhost
+API.allowed = *
+
+# Does the API accept additional/redundant parameters in an API call?
+# default is no (Wallet accepts only params specified for given call)
+# enable this if you have a sloppy client interacting, but please be aware that this
+# can be a security risk.
+API.AcceptSurplusParams = no
+
+# Host interface on which to listen for http/json API request, default localhost only.
+# Set to 0.0.0.0 to allow the API server to accept requests from all network interfaces.
+API.Listen = 0.0.0.0
+
+# Port for http/json API requests.
+API.Port = 8125
+
+# Idle timeout for http/json API request connections, milliseconds.
+API.ServerIdleTimeout = 30000
+
+# Directory with html and javascript files for the new client UI, and admin tools utilizing
+# the http/json API.
+API.UI_Dir = html/ui
+
+# Enable Cross Origin Filter for the API server.
+API.CrossOriginFilter = off
+
+# Enable SSL for the API server (also need to set API.SSL_keyStorePath and API.SSL_keyStorePassword).
+API.SSL = off
+
+# Enforce requests that require POST to only be accepted when submitted as POST.
+API.ServerEnforcePOST = yes
+
+# keystore file and password, required if uiSSL or apiSSL are enabled.
+API.SSL_keyStorePath     = keystore
+API.SSL_keyStorePassword = password
+
+#### DATABASE ####
+
+# Database connection JDBC url
+# Append ;AUTO_SERVER=TRUE to enable automatic mixed mode access.
+DB.Url=jdbc:h2:file:/db/burst;DB_CLOSE_ON_EXIT=FALSE
+DB.Username=
+DB.Password=
+
+# Number of concurrent connections to the Database
+DB.Connections = 30
+
+# Make H2 database defrag and compact when shutting down.
+# This is "off" by default as it can take 2 minutes
+# but you really want this to be on after you are aware of this option
+Db.H2.DefragOnShutdown = off
+
+# Enable trimming of derived objects tables.
+DB.trimDerivedTables = on
+
+# If trimming enabled, maintain enough previous height records to allow rollback of at least
+# that many blocks. Must be at least 1440 to allow normal fork resolution. After increasing
+# this value, a full re-scan needs to be done in order for previously trimmed records to be
+# re-created and preserved.
+DB.maxRollback = 1440
+
+# Database default lock timeout in seconds.
+DB.LockTimeout = 60
+
+### GPU Acceleration
+
+# enable GPU acceleration
+GPU.Acceleration = off
+GPU.AutoDetect   = on
+
+# If GPU auto-detection is off (GPU.AutoDetect = off), you must specify manually which one to use
+GPU.PlatformIdx = 0
+GPU.DeviceIdx   = 0
+
+# GPU memory usage in percent and how many hashes to process in one batch
+GPU.MemPercent       = 50
+GPU.HashesPerBatch = 1000
+
+# number of unverified transactions in cache before GPU verification starts.
+GPU.UnverifiedQueue = 1000
+
+# Uncomment this to limit the number of cpu cores the wallet sees. Default is all available.
+# CPU.NumCores = 4
+
+
+#### DEVELOPMENT ####
+# (mere mortals do not need to look beyond this point)
+
+# Set to "yes" to run offline - do not connect to peers and do not listen for incoming peer
+# connections. This is equivalent to setting brs.shareMyAddress = no, brs.wellKnownPeers = ,
+# DEV.P2P.BootstrapPeers = and brs.usePeersDb = no, and if set to "yes" overrides those properties.
+DEV.Offline = no
+
+# Use testnet, leave set to false unless you are really testing.
+# Never unlock your real accounts on testnet! Use separate accounts for testing only.
+# When using testnet, all custom port settings will be ignored,
+# and hardcoded ports of 6874 (peer networking), 6875 (UI) and 6876 (API) will be used.
+DEV.TestNet = no
+
+# Database connection JDBC url to use with the test network, if DEV.TestNet
+DEV.DB.Url =
+DEV.DB.Username =
+DEV.DB.Password =
+
+# Time Acceleration in Offline/TestNet configurations (1 = normal time, 2 = twice as fast ...)
+DEV.TimeWarp = 1
+
+# Peers used for testnet only.
+DEV.P2P.BootstrapPeers =
+
+# Testnet only. These peers will always be sent rebroadcast transactions. They are also automatically added to DEV.P2P.BootstrapPeers, so no need for duplicates.
+DEV.P2P.rebroadcastTo =
+
+# Force winning with every deadline
+DEV.mockMining = off
+
+# Enter a version. Upon exit, print a list of peers having this version.
+DEV.dumpPeersVersion =
+
+# Force re-validation of blocks and transaction at start.
+DEV.forceValidate = off
+
+# Force re-build of derived objects tables at start.
+DEV.forceScan = off
+
+
+# Debugging (part of Development - isn't it)
+
+# Used for debugging peer to peer communications.
+brs.communicationLoggingMask = 0
+
+# Track balances of the following accounts and related events for debugging purposes.
+brs.debugTraceAccounts=
+
+# File name for logging tracked account balances.
+brs.debugTraceLog = LOG_AccountBalances_trace.csv
+
+# Separator character for trace log. (default '\t' - TAB)
+brs.debugTraceSeparator =
+
+# Quote character for trace log. (default " - double quote)
+brs.debugTraceQuote =
+
+# Log changes to unconfirmed balances.
+brs.debugLogUnconfirmed = false

--- a/conf/brs.properties.mariadb
+++ b/conf/brs.properties.mariadb
@@ -1,0 +1,310 @@
+############################################################
+# Do not modify this file.  Instead, create a file named   #
+# 'brs.properties' in the conf directory and make your     #
+# changes there.                                           #
+# These will overwrite the values defined here!            #
+############################################################
+#
+# Integer parameters can be
+# decimal     123
+# binary      0b100101
+# hexadecimal 0xAF1D
+#
+# Boolean parameters can be
+# 1, true, yes, on
+# 0, false, no, off
+# (case insensitive)
+#
+
+#### PEER 2 PEER NETWORKING ####
+
+# Announce my IP address/hostname to peers and allow them to share it with other peers.
+# If disabled, peer networking servlet will not be started at all.
+P2P.shareMyAddress = yes
+
+# My externally visible IP address or host name, to be announced to peers.
+# It can optionally include a port number, which will also be announced to peers,
+# and may be different from P2P.Port (useful if you do port forwarding behind a router).
+P2P.myAddress =
+
+# Host interface on which to listen for peer networking requests, default all.
+# Use 0.0.0.0 to listen on all IPv4 interfaces or :: to listen on all IPv4 and IPv6 interfaces
+P2P.Listen = 0.0.0.0
+
+# Port for incoming peer to peer networking requests, if enabled.
+P2P.Port = 8123
+
+# Use UPnP-Portforwarding
+P2P.UPnP = yes
+
+# My platform, to be announced to peers.
+P2P.myPlatform = PC
+
+# A list of peer addresses / host names, separated by '; ' used for faster P2P networking bootstrap.
+# TODO: document what is taken if not set
+
+P2P.BootstrapPeers = 163.172.162.223; node.burst.gittam.de; 80.122.157.25; 138.201.247.112; 35.194.43.230; 24.179.36.64; 136.243.54.19; 160.16.52.180; [2a02:c207:2016:1984:0:0:0:1]; wallet.smit.pro; wallet.logg.coffee; 37.205.11.73; 47.95.232.75; 75.100.126.230; 93.73.103.148; wallet.burst.cryptoguru.org; 51.15.95.163; antigo.hopto.org; 61.171.0.50; burst.megash.it; wi3jodsj.dynu.net; 176.31.105.109; 24.51.189.190; burstwallet2.ddns.net; burstsecurity.com; 81.83.5.50; bloodreaver.no-ip.biz; burstnode.devtrue.net; 185.203.117.157; 138.201.159.96; 52.65.42.199; 138.201.159.82; 159.69.21.174; home.schmiemann.online; 221.241.92.2; peer.wallet.burstcoin.ml; [2a03:3b40:100:0:0:0:1:52]; tompkins.ddns.net; 188.68.41.245; wallet.creepminer.net; burstpool.cloud; 173.249.1.215; 91.143.92.133:18123; 80.71.133.195; redfox.org; 146.247.237.139; 77.70.109.7; 117.48.195.3; 144.76.92.28; bangalore.burstsecurity.com; wallet.burstcoin.asia; 78.130.235.166; aa.storj.eu; 195.201.124.43; wallet.daggeringcats.com; 84.113.147.25; 81.169.131.111; 5.39.93.90; 198.100.149.133; 148.251.78.147; 212.32.255.2; 195.201.116.237; 95.216.142.146; 84.72.183.85; 75.100.126.227; 35.207.44.92; 75.100.126.226; 107.150.6.121; burst.sagichdir.net; [2a07:5741:0:b12:0:0:0:1]; 108.238.244.144; 51.15.219.28; 81.217.76.37; bibenwei.com; 82.192.26.82; logg.coffee; burst-fi.megash.it; 87.227.172.104; 45.76.6.179; chorca.com; 87.98.244.116; 5.189.177.212; 207.38.188.197; 83.87.55.43; 151.248.189.93; 45.32.114.77; 95.165.132.145; 91.143.92.133; 85.217.171.59; 78.46.245.194; 47.33.52.184; www.ollb.de; [2001:19f0:4400:6c35:5400:1ff:fe54:840]; 83.170.94.221; kartoffel.space:8000; 185.203.116.80; 39.106.178.146; 62.210.254.125; 80.65.49.246; 88.198.32.19; carless.ddns.net; 89.166.9.172; 94.130.190.156; 45.77.250.34; 144.76.45.125; 95.216.0.50; 185.185.27.163; 75.100.126.22875.100.126.229; [2a07:5741:0:f8c:0:0:0:1]; 5.103.129.103; 213.32.102.141; 63.251.20.214
+
+# These peers will always be sent rebroadcast transactions. They are also automatically added to P2P.BootstrapPeers, so no need for duplicates.
+P2P.rebroadcastTo = 78.46.245.194; 94.130.190.156; 78.130.235.166; 75.100.126.230; 195.201.116.237; 75.100.126.226; 138.201.159.82
+
+# Connect to this many bootstrap connection peers before using the peer database to get connected faster. Please be aware, that higher != better (3-5 are usually good values) Set to 0 or comment out to disable.
+P2P.NumBootstrapConnections = 4
+
+# Known bad peers to be blacklisted
+P2P.BlacklistedPeers =
+
+# Maintain active connections with at least that many peers. Also more != better (you want good peers, not just many)
+P2P.MaxConnections = 20
+
+# Use Peers Database? (Only if not in Offline mode)
+P2P.usePeersDb = yes
+# Save known peers in the PeersDB? (only if P2P.usePeersDB is true)
+P2P.savePeers = yes
+
+# Set to false to disable getting more peers from the currently connected peers. Only useful
+# when debugging and want to limit the peers to those in peersDb or P2P.BootstrapPeers.
+P2P.getMorePeers = yes
+
+# If database of peers exceed this value more peers will not be downloaded.
+# This value will never be below MaxConnections. To high value will slowdown connections.
+P2P.getMorePeersThreshold = 400
+
+# Peer networking connect timeout for outgoing connections.
+P2P.TimeoutConnect_ms = 4000
+# Peer networking read timeout for outgoing connections.
+P2P.TimeoutRead_ms = 8000
+# Peer networking server idle timeout, milliseconds.
+P2P.TimeoutIdle_ms = 30000
+# Blacklist peers for 600000 milliseconds (i.e. 10 minutes by default).
+P2P.BlacklistingTime_ms = 600000
+
+# Enable re-broadcasting of new transactions until they are received back from at least one
+# peer, or found in the blockchain. This feature can optionally be disabled, to avoid the
+# risk of revealing that this node is the submitter of such re-broadcasted new transactions.
+P2P.enableTxRebroadcast = yes
+
+# Transactions that aren't confirmed for this many blocks start getting rebroadcast.
+P2P.rebroadcastTxAfter = 5
+
+# Transactions being rebroadcast get rebroadcast every this many blocks until they are confirmed.
+P2P.rebroadcastTxEvery = 2
+
+# Consider a new transaction or block sent after 10 peers have received it.
+P2P.sendToLimit=10
+
+# Max number of unconfirmed transactions that will be kept in cache.
+P2P.maxUnconfirmedTransactions = 8192
+
+# Max percentage of unconfirmed transactions that have a full hash reference to another transaction kept in cache
+P2P.maxUnconfirmedTransactionsFullHashReferencePercentage = 5
+
+# Max amount of unconfirmed transactions that will be asked to a peer at the same time
+P2P.limitUnconfirmedTransactionsToRetrieve = 1000
+
+# JETTY pass-through options. See documentation at
+# https://www.eclipse.org/jetty/documentation/9.2.22.v20170531/dos-filter.html
+# P2P section:
+JETTY.P2P.DoSFilter                   = on
+JETTY.P2P.DoSFilter.maxRequestsPerSec = 30
+JETTY.P2P.DoSFilter.delayMs           = 500
+JETTY.P2P.DoSFilter.maxRequestMs      = 300000
+JETTY.P2P.DoSFilter.throttleMs        = 30000
+JETTY.P2P.DoSFilter.maxIdleTrackerMs  = 30000
+JETTY.P2P.DoSFilter.maxWaitMs         = 50
+JETTY.P2P.DoSFilter.throttledRequests = 5
+JETTY.P2P.DoSFilter.insertHeaders     = true
+JETTY.P2P.DoSFilter.trackSessions     = false
+JETTY.P2P.DoSFilter.remotePort        = false
+JETTY.P2P.DoSFilter.ipWhitelist       = ""
+JETTY.P2P.DoSFilter.managedAttr       = true
+
+# see https://www.eclipse.org/jetty/documentation/9.2.22.v20170531/gzip-filter.html
+# deflate compression and others ommitted on purpose (pending update to GzipHandler anyway)
+JETTY.P2P.GZIPFilter             = on
+JETTY.P2P.GZIPFilter.methods     = "GET, POST"
+JETTY.P2P.GZIPFilter.bufferSize  = 8192
+JETTY.P2P.GZIPFilter.minGzipSize = 0
+
+# Size of the download cache for blocks
+brs.blockCacheMB = 40
+
+#### API SERVER ####
+
+# Accept http/json API requests.
+API.Server = on
+
+# JETTY pass-through options. See documentation at
+# https://www.eclipse.org/jetty/documentation/9.2.22.v20170531/dos-filter.html
+# API section:
+JETTY.API.DoSFilter                   = off
+JETTY.API.DoSFilter.maxRequestsPerSec = 30
+JETTY.API.DoSFilter.delayMs           = 500
+JETTY.API.DoSFilter.maxRequestMs      = 30000
+JETTY.API.DoSFilter.throttleMs        = 30000
+JETTY.API.DoSFilter.maxIdleTrackerMs  = 30000
+JETTY.API.DoSFilter.maxWaitMs         = 50
+JETTY.API.DoSFilter.throttledRequests = 5
+JETTY.API.DoSFilter.insertHeaders     = true
+JETTY.API.DoSFilter.trackSessions     = false
+JETTY.API.DoSFilter.remotePort        = false
+JETTY.API.DoSFilter.ipWhitelist       = ""
+JETTY.API.DoSFilter.managedAttr       = true
+
+# Jetty-passthrough parameters for API responses GZIP compression. See JETTY.P2P.GZIPFilter
+JETTY.API.GZIPFilter             = off
+JETTY.API.GZIPFilter.methods     = "GET, POST"
+JETTY.API.GZIPFilter.bufferSize  = 8192
+JETTY.API.GZIPFilter.minGzipSize = 0
+
+# Developers or maintenance only! Enable API requests used for
+# blockchain and database manipulation. If this is enabled and your
+# wallet is public, you are very vulnerable.
+API.Debug = off
+
+# Hosts or subnets from which to allow http/json API requests, if enabled.
+# List delimited by ';', IPv4/IPv6 possible, default: localhost
+API.allowed = *
+
+# Does the API accept additional/redundant parameters in an API call?
+# default is no (Wallet accepts only params specified for given call)
+# enable this if you have a sloppy client interacting, but please be aware that this
+# can be a security risk.
+API.AcceptSurplusParams = no
+
+# Host interface on which to listen for http/json API request, default localhost only.
+# Set to 0.0.0.0 to allow the API server to accept requests from all network interfaces.
+API.Listen = 0.0.0.0
+
+# Port for http/json API requests.
+API.Port = 8125
+
+# Idle timeout for http/json API request connections, milliseconds.
+API.ServerIdleTimeout = 30000
+
+# Directory with html and javascript files for the new client UI, and admin tools utilizing
+# the http/json API.
+API.UI_Dir = html/ui
+
+# Enable Cross Origin Filter for the API server.
+API.CrossOriginFilter = off
+
+# Enable SSL for the API server (also need to set API.SSL_keyStorePath and API.SSL_keyStorePassword).
+API.SSL = off
+
+# Enforce requests that require POST to only be accepted when submitted as POST.
+API.ServerEnforcePOST = yes
+
+# keystore file and password, required if uiSSL or apiSSL are enabled.
+API.SSL_keyStorePath     = keystore
+API.SSL_keyStorePassword = password
+
+#### DATABASE ####
+
+# Database connection JDBC url
+# Append ;AUTO_SERVER=TRUE to enable automatic mixed mode access.
+DB.Url=jdbc:mariadb://mariadb:3306/burst
+DB.Username=root
+DB.Password=burst
+
+# Number of concurrent connections to the Database
+DB.Connections = 30
+
+# Make H2 database defrag and compact when shutting down.
+# This is "off" by default as it can take 2 minutes
+# but you really want this to be on after you are aware of this option
+Db.H2.DefragOnShutdown = off
+
+# Enable trimming of derived objects tables.
+DB.trimDerivedTables = on
+
+# If trimming enabled, maintain enough previous height records to allow rollback of at least
+# that many blocks. Must be at least 1440 to allow normal fork resolution. After increasing
+# this value, a full re-scan needs to be done in order for previously trimmed records to be
+# re-created and preserved.
+DB.maxRollback = 1440
+
+# Database default lock timeout in seconds.
+DB.LockTimeout = 60
+
+### GPU Acceleration
+
+# enable GPU acceleration
+GPU.Acceleration = off
+GPU.AutoDetect   = on
+
+# If GPU auto-detection is off (GPU.AutoDetect = off), you must specify manually which one to use
+GPU.PlatformIdx = 0
+GPU.DeviceIdx   = 0
+
+# GPU memory usage in percent and how many hashes to process in one batch
+GPU.MemPercent       = 50
+GPU.HashesPerBatch = 1000
+
+# number of unverified transactions in cache before GPU verification starts.
+GPU.UnverifiedQueue = 1000
+
+# Uncomment this to limit the number of cpu cores the wallet sees. Default is all available.
+# CPU.NumCores = 4
+
+
+#### DEVELOPMENT ####
+# (mere mortals do not need to look beyond this point)
+
+# Set to "yes" to run offline - do not connect to peers and do not listen for incoming peer
+# connections. This is equivalent to setting brs.shareMyAddress = no, brs.wellKnownPeers = ,
+# DEV.P2P.BootstrapPeers = and brs.usePeersDb = no, and if set to "yes" overrides those properties.
+DEV.Offline = no
+
+# Use testnet, leave set to false unless you are really testing.
+# Never unlock your real accounts on testnet! Use separate accounts for testing only.
+# When using testnet, all custom port settings will be ignored,
+# and hardcoded ports of 6874 (peer networking), 6875 (UI) and 6876 (API) will be used.
+DEV.TestNet = no
+
+# Database connection JDBC url to use with the test network, if DEV.TestNet
+DEV.DB.Url =
+DEV.DB.Username =
+DEV.DB.Password =
+
+# Time Acceleration in Offline/TestNet configurations (1 = normal time, 2 = twice as fast ...)
+DEV.TimeWarp = 1
+
+# Peers used for testnet only.
+DEV.P2P.BootstrapPeers =
+
+# Testnet only. These peers will always be sent rebroadcast transactions. They are also automatically added to DEV.P2P.BootstrapPeers, so no need for duplicates.
+DEV.P2P.rebroadcastTo =
+
+# Force winning with every deadline
+DEV.mockMining = off
+
+# Enter a version. Upon exit, print a list of peers having this version.
+DEV.dumpPeersVersion =
+
+# Force re-validation of blocks and transaction at start.
+DEV.forceValidate = off
+
+# Force re-build of derived objects tables at start.
+DEV.forceScan = off
+
+
+# Debugging (part of Development - isn't it)
+
+# Used for debugging peer to peer communications.
+brs.communicationLoggingMask = 0
+
+# Track balances of the following accounts and related events for debugging purposes.
+brs.debugTraceAccounts=
+
+# File name for logging tracked account balances.
+brs.debugTraceLog = LOG_AccountBalances_trace.csv
+
+# Separator character for trace log. (default '\t' - TAB)
+brs.debugTraceSeparator =
+
+# Quote character for trace log. (default " - double quote)
+brs.debugTraceQuote =
+
+# Log changes to unconfirmed balances.
+brs.debugLogUnconfirmed = false


### PR DESCRIPTION
This PR adds two Dockerfiles: one for H2, one for MariaDB. Furthermore default configs for these have been added into the config dir. I based them off the current default properties file and added the necessary changes as seen in the burstcoin-docker repo.

I noticed 2.3.0 wont start without `-Ddev=1` (not a big java expert, but suppose `dev` should just not be null). This is due to the version check in `Burst.java`. Not sure what that is about.

In docker hub a build schema like the following is probably desired:
![grafik](https://user-images.githubusercontent.com/5189997/46954965-1cb18a00-d092-11e8-9b01-9474bff575cc.png)

It will build `latest` and `mariadb` on each push to master and use semver tags (full x.y.z and minor only x.y) and append h2 or mariadb respectively (eg. `2.3.0-h2` and `2.3-h2`).

I updated the README with a chapter about Docker copied from the current repo (https://hub.docker.com/r/burstcoin/core/). One will need to update the image name to the correct ones once the final name is known.

Closes #412 