### PR TITLE
Fix UTstore with FullHash

### DIFF
--- a/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
+++ b/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
@@ -118,7 +118,7 @@ public class UnconfirmedTransactionStoreImpl implements UnconfirmedTransactionSt
   }
 
   private boolean tooManyTransactionsWithReferencedFullHash(Transaction transaction) {
-    return ! StringUtils.isEmpty(transaction.getReferencedTransactionFullHash()) && maxPercentageUnconfirmedTransactionsFullHash <= (((numberUnconfirmedTransactionsFullHash + 1) / maxSize) * 100);
+    return ! StringUtils.isEmpty(transaction.getReferencedTransactionFullHash()) && numberUnconfirmedTransactionsFullHash >  (double) maxSize / 100. * (double) maxPercentageUnconfirmedTransactionsFullHash);
   }
 
   private boolean cacheFullAndTransactionCheaperThanAllTheRest(Transaction transaction) {

--- a/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
+++ b/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
@@ -118,7 +118,7 @@ public class UnconfirmedTransactionStoreImpl implements UnconfirmedTransactionSt
   }
 
   private boolean tooManyTransactionsWithReferencedFullHash(Transaction transaction) {
-    return ! StringUtils.isEmpty(transaction.getReferencedTransactionFullHash()) && maxPercentageUnconfirmedTransactionsFullHash <= (((numberUnconfirmedTransactionsFullHash + 1) * 100) / maxSize);
+    return ! StringUtils.isEmpty(transaction.getReferencedTransactionFullHash()) && maxPercentageUnconfirmedTransactionsFullHash <= (((numberUnconfirmedTransactionsFullHash + 1) / maxSize) * 100);
   }
 
   private boolean cacheFullAndTransactionCheaperThanAllTheRest(Transaction transaction) {

--- a/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
+++ b/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
@@ -118,7 +118,7 @@ public class UnconfirmedTransactionStoreImpl implements UnconfirmedTransactionSt
   }
 
   private boolean tooManyTransactionsWithReferencedFullHash(Transaction transaction) {
-    return ! StringUtils.isEmpty(transaction.getReferencedTransactionFullHash()) && numberUnconfirmedTransactionsFullHash >  (double) maxSize / 100. * (double) maxPercentageUnconfirmedTransactionsFullHash);
+    return ! StringUtils.isEmpty(transaction.getReferencedTransactionFullHash()) && numberUnconfirmedTransactionsFullHash > ((double) maxSize / 100.) * (double) maxPercentageUnconfirmedTransactionsFullHash);
   }
 
   private boolean cacheFullAndTransactionCheaperThanAllTheRest(Transaction transaction) {


### PR DESCRIPTION
Fix limit detection Unconfirmed Transactions store with FullHashReference
With the default brs config, the previous implementation required at least 409 UT with FullHashReference before 1 could be stored.