### PR TITLE
Reflect docker org and repo changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ DB.Password=yourpassword
 
 `latest` : Latest tag of the BRS with H2 database  
 `mariadb` : Latest tag of the BRS with MariaDB database  
-`2.2.3-h2`, `2.2-h2` : Version 2.2.3 of the BRS with H2 database  
-`2.2.3-mariadb`, `2.2-mariadb` : Version 2.2.3 of the BRS with MariaDB database  
+`2.2.6-h2`, `2.2-h2`, `2-h2` : Version 2.2.6 of the BRS with H2 database  
+`2.2.6-mariadb`, `2.2-mariadb`, `2-mariadb` : Version 2.2.6 of the BRS with MariaDB database  
 
 
 **Note (H2 only):**  
@@ -126,7 +126,7 @@ version: '3'
 
 services:
   burstcoin:
-    image: burstcoin/core:2.2-mariadb
+    image: pocconsortium/burstcoin:2-mariadb
     restart: always
     depends_on:
      - mariadb
@@ -147,7 +147,7 @@ services:
 ##### H2
 
 ```
-docker run -p 8123:8123 -p 8125:8125 -v "$(pwd)"/burst_db:/db -d burstcoin/core:2.2-h2
+docker run -p 8123:8123 -p 8125:8125 -v "$(pwd)"/burst_db:/db -d pocconsortium/burstcoin:2-h2
 ```
 
 


### PR DESCRIPTION
Due to the new docker org and repo the README is outdated. This PR fixes that.