### PR TITLE
fix(send): improve messaging when sending to acct with no publicKey

### DIFF
--- a/html/ui/js/brs.recipient.js
+++ b/html/ui/js/brs.recipient.js
@@ -189,7 +189,7 @@ var BRS = (function(BRS, $, undefined) {
                 } else {
                     callback({
                         "type": "warning",
-                        "message": $.t("recipient_no_public_key_pka", {
+                        "message": $.t("recipient_no_public_key", {
                             "burst": BRS.formatAmount(response.unconfirmedBalanceNQT, false, true)
                         }),
                         "account": response,


### PR DESCRIPTION
Closes https://github.com/PoC-Consortium/burstcoin/issues/427

Now it will say "The recipient account does not have a public key, meaning it has never had an outgoing transaction. The account has a balance of __burst__ BURST. Please double check your recipient address before submitting."